### PR TITLE
docs: Fix simple typo, consturctor -> constructor

### DIFF
--- a/src/api/register.js
+++ b/src/api/register.js
@@ -22,7 +22,7 @@ import { getRegisterOptions } from '../support/util';
  *    class BasicForms extends PureComponent {
  *      constructor(props, context) {
  *        super(props, context);
- *        props.$$attach(this);// must call $$attach at last line of consturctor block
+ *        props.$$attach(this);// must call $$attach at last line of constructor block
  *      }
  *      render(){
  *        this.ctx.moduleComputed; //now you can get render ctx supplied by concent

--- a/src/core/base/register.js
+++ b/src/core/base/register.js
@@ -123,7 +123,7 @@ export default function register({
           // 属性代理模式，必需在组件consturctor里调用 props.$$attach(this)
           // you must call it in next line of state assign expression 
           if (isPropsProxy && !this.ctx.childRef) {
-            throw new Error(`forget call props.$$attach(this) in consturctor when set isPropsProxy true`);
+            throw new Error(`forget call props.$$attach(this) in constructor when set isPropsProxy true`);
           }
 
           if (super.componentDidMount) super.componentDidMount();


### PR DESCRIPTION
There is a small typo in src/api/register.js, src/core/base/register.js.

Should read `constructor` rather than `consturctor`.

