### PR TITLE
Make contributing to docs easier

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -32,13 +32,15 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          editUrl: 'https://github.com/tnfe/hel/doc',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/heluxjs/helux/master/editor/doc/docs/${docPath}`
+          },
         },
         blog: {
           showReadingTime: true,
-          // Please change this to your repo.
-          editUrl: 'http://localhost:3000/hel/blog',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/heluxjs/helux/master/editor/doc/blog/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/heluxjs/helux/master/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb